### PR TITLE
Add asciidoc plugin

### DIFF
--- a/_src/index.adoc
+++ b/_src/index.adoc
@@ -1,21 +1,9 @@
----
-layout: default.liquid
-pagination:
-# Dupe this page on 'co/index.html'
-# see https://github.com/11ty/eleventy/issues/326#issuecomment-444127344
-    data: pagenames
-    alias: url
-    size: 1
-pagenames:
-    - index
-    - co/index
-permalink: "{{ url }}.html"
----
-# sepheo coop
+// (See note about frontmatters in op.adoc)
+= sepheo coop
 
 SEPHEO (Self-Employed People Helping Each Other) Coop is a mutual society for self-employed professionals. We make it easy for freelancers to connect with coops and other aligned organisations.
 
-As a coop, we subscribe to the [Rochdale Co-operative principles](https://en.wikipedia.org/wiki/Rochdale_Principles), and the [Solidarity Economy principles](https://solidarityeconomyprinciples.org/).
+As a coop, we subscribe to the https://en.wikipedia.org/wiki/Rochdale_Principles[Rochdale Co-operative principles], and the https://solidarityeconomyprinciples.org/[Solidarity Economy principles].
 
 The problem: whilst employment in a typical company can be alienating (for reasons well understood to the co-op movement), co-ops are not a widely accessible alternative for most people. Their relative rarity, low visibility and unfamiliarity mean they're often not perceived as existing, yet alone as a possible alternative - even then they may be dismissed. In the other direction, co-ops often require a much higher degree of trust to grant membership than they would employment.
 
@@ -27,16 +15,15 @@ Sepheo connects co-operatives and freelancers by regularly checking-in with coop
 
 In the long term we want to act as a generative force in the coop economy, multiplying the efforts of others beyond what they thought possible.
 
-<div id="links">
+[#links]
+--
 
-Join our list of freelancers <a href="/register" target="_blank">here</a>.
+Join our list of freelancers link:/register[here^].
 
-OpenCollective: <a href="https://opencollective.com/sepheocoop#category-ABOUT"
-  target="_blank">opencollective.com/sepheocoop</a>
+OpenCollective: https://opencollective.com/sepheocoop#category-ABOUT[opencollective.com/sepheocoop^]
 
-GitHub: <a href="https://github.com/sepheocoop"
-  target="_blank">github.com/sepheocoop</a>
+GitHub: https://github.com/sepheocoop[github.com/sepheocoop^]
 
-E-mail: <a>contact<span class="mono at">sepheo.co</a>
+E-mail: mailto:contact@sepheo.co[]
 
-</div>
+--

--- a/_src/op.adoc
+++ b/_src/op.adoc
@@ -1,0 +1,15 @@
+include::index.adoc[]
+////
+NOTE: this file exists to allow URLs to https://sepheo.co/op to reach
+the landing page content.
+
+It replaces the mechanism used with a markdown index.md, which doesn't
+currently work with AsciiDoc. See https://github.com/saneef/eleventy-plugin-asciidoc/issues/21
+
+However, a front-matter block (delimited with `---`) *may* be inserted
+into an .adoc file in the context of Elventy, using
+eleventy-asciidoc-plugin.  However, this will get inserted verbatim as
+text when combined with the include above.  So we don't do that!
+
+Front-matter blocks are otherwise fine in .adoc files.
+////

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,4 +1,5 @@
 import { EleventyHtmlBasePlugin } from "@11ty/eleventy";
+import EleventyAsciidoc from "eleventy-plugin-asciidoc";
 import less from "less";
 import { existsSync, rmSync } from "node:fs";
 
@@ -20,6 +21,12 @@ export default function (config) {
     jsTruthy: true,
   });
   config.addPlugin(EleventyHtmlBasePlugin);
+  config.addPlugin(EleventyAsciidoc, {
+    attributes: {
+      showtitle: true, // Makes level 1 headings -> <h1> + <title>, instead of just <title>
+    },
+    safe: "unsafe",
+  });
 
   // Transform less.js
   // Adapted from https://www.11ty.dev/docs/languages/custom/#example-add-sass-support-to-eleventy

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@11ty/eleventy": "^3.0.0",
+        "eleventy-plugin-asciidoc": "^4.0.2",
         "less": "^4.2.2",
         "prettier": "^3.4.2"
       },
@@ -202,6 +203,74 @@
         "promise": "^7.0.1",
         "rimraf": "^5.0.7",
         "slash": "^1.0.0"
+      }
+    },
+    "node_modules/@asciidoctor/core": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-3.0.4.tgz",
+      "integrity": "sha512-41SDMi7iRRBViPe0L6VWFTe55bv6HEOJeRqMj5+E5wB1YPdUPuTucL4UAESPZM6OWmn4t/5qM5LusXomFUVwVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asciidoctor/opal-runtime": "3.0.1",
+        "unxhr": "1.2.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@asciidoctor/opal-runtime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/opal-runtime/-/opal-runtime-3.0.1.tgz",
+      "integrity": "sha512-iW7ACahOG0zZft4A/4CqDcc7JX+fWRNjV5tFAVkNCzwZD+EnFolPaUOPYt8jzadc0+Bgd80cQTtRMQnaaV1kkg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "8.1.0",
+        "unxhr": "1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@asciidoctor/opal-runtime/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@asciidoctor/opal-runtime/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@asciidoctor/opal-runtime/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -721,6 +790,21 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
+    "node_modules/eleventy-plugin-asciidoc": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-asciidoc/-/eleventy-plugin-asciidoc-4.0.2.tgz",
+      "integrity": "sha512-jtty+JGj56S8AAGolTpi7BVyHjVn8x+gIJJQnK9z89gd0jj7YOfNc+SiY6v2L11WH8WFokcxbwopkZLfvbRl7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@asciidoctor/core": "^3.0.4",
+        "debug": "^4.3.4",
+        "gray-matter": "^4.0.3",
+        "nunjucks": "^3.2.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/saneef/"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -943,6 +1027,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1208,6 +1298,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -1721,6 +1822,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -2288,6 +2398,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unxhr": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.2.0.tgz",
+      "integrity": "sha512-6cGpm8NFXPD9QbSNx0cD2giy7teZ6xOkCUH3U89WKVkL9N9rBrWjlCwhR94Re18ZlAop4MOc3WU1M3Hv/bgpIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.11"
+      }
+    },
     "node_modules/urlpattern-polyfill": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
@@ -2390,6 +2509,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@11ty/eleventy": "^3.0.0",
+    "eleventy-plugin-asciidoc": "^4.0.2",
     "less": "^4.2.2",
     "prettier": "^3.4.2"
   },


### PR DESCRIPTION
## Problem
- We have some AsciiDoc documents we would like to publish on the website
- AsciiDoc has some advantages over Markdown which might help make things easier (although there may be trade-offs - however, we can still use Markdown on a document by document basis)

## Proposed resolution
- Include the asciidoc plugin to allow it to be rendered
- Test translating the index into AsciiDoc

This makes it a bit easier to, for instance, insert things like blank target urls without resorting to raw HTML in Markdown.

## Niggles

There was a bit of a problem keeping the https://sepheo.co/op link working, and retaining the H1 header, but these have been resolved, see notes in commits and code comments.

The result should look essentially identical to the previous version, modulo some minor line-spacing changes.